### PR TITLE
fix(api): account register endpoint not requiring mail confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # unitystation_auth
+![Docker Image Version (latest by date)](https://img.shields.io/docker/v/unitystation/unitystation_auth)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/38cce37d4c854ca48645fd5ecc9cae61)](https://www.codacy.com/gh/unitystation/unitystation_auth/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=unitystation/unitystation_auth&amp;utm_campaign=Badge_Grade)
 
 ### Development guide
 #### Setting up Docker

--- a/src/account/api/serializers.py
+++ b/src/account/api/serializers.py
@@ -1,7 +1,9 @@
 import django.contrib.auth.password_validation as validators
 
+from django.conf import settings
 from django.core import exceptions
 from rest_framework import serializers
+from django_email_verification import sendConfirm
 
 from account.models import Account
 
@@ -22,7 +24,11 @@ class RegisterAccountSerializer(serializers.ModelSerializer):
 
         password = self.validated_data["password"]
         account.set_password(password)
-        account.save()
+
+        if settings.REQUIRE_EMAIL_CONFIRMATION:
+            sendConfirm(account)
+        else:
+            account.save()
 
         return account
 


### PR DESCRIPTION
quite easy fix. The mail confirmation wasn't being called and the user was directly saved into the db with active status.
fixes #4 