### PR TITLE
fix(docker): poetry has quite a few dependencies, might be a good idea to remove them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache libpq \
     && pip install poetry \
     && poetry config virtualenvs.create false \
     && poetry install --no-dev \
+    && pip uninstall poetry -y \
     && apk del --purge .build-deps
 
 COPY src .


### PR DESCRIPTION
Dependencies: cachecontrol, keyring, clikit, requests, pkginfo, pexpect, shellingham, tomlkit, poetry-core, requests-toolbelt, cleo, html5lib, packaging, virtualenv, crashtest, cachy