### PR TITLE
refactor: added whitenoise to the project

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -258,6 +258,17 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [[package]]
+name = "whitenoise"
+version = "6.2.0"
+description = "Radically simplified static file serving for WSGI applications"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+brotli = ["brotli"]
+
+[[package]]
 name = "wrapt"
 version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -268,7 +279,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "3ec4b859a5fb395618762d8b3680e784e9513d77528b4320a14b6d79a01bfeaf"
+content-hash = "3a8d9d6f61ab2c08c412f3f2645881b2d824f3e0b146eaf0ac50b85dc0c14c84"
 
 [metadata.files]
 asgiref = [
@@ -519,6 +530,7 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 tomlkit = []
+whitenoise = []
 wrapt = [
     {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
     {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ django-email-verification = "^0.0.7"
 django-rest-knox = "^4.1.0"
 gunicorn = "^20.1.0"
 python-dotenv = "^0.19.2"
+whitenoise = "^6.2.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.6.0"

--- a/src/central-command/settings.py
+++ b/src/central-command/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django_email_verification",
     "rest_framework",
@@ -52,6 +53,8 @@ AUTH_USER_MODEL = "accounts.Account"
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -170,3 +173,6 @@ MEDIA_ROOT = Path("/home", "website", "media")
 # LOGOUT_REDIRECT_URL = "home"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Whitenoise statics compression and caching
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"


### PR DESCRIPTION
Whitenoise is a package for django that allows us to serve the static files safely without having to deal with nginx.

This is required so we don't have issues serving the few static files needed to interact with the debug views of django rest.

This makes no changes whatsoever on the clientside.