### PR TITLE
chore: tweak workflows for staging and production environments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,7 @@ on:
             - "*"
     push:
         branches:
-            - main
             - develop
-        tags:
-            - "v*"
 
 env:
     IMAGE_NAME: unitystation/central-command
@@ -17,70 +14,62 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v4
-              with:
-                  python-version: '3.11'
+            -   uses: actions/checkout@v4
+            -   uses: actions/setup-python@v4
+                with:
+                    python-version: '3.11'
             # because pre-commit uses external mypy
-            - name: install mypy
-              run: |
-                  pip install poetry
-                  poetry config virtualenvs.create false
-                  poetry install --only main,typecheck
+            -   name: install mypy
+                run: |
+                    pip install poetry
+                    poetry config virtualenvs.create false
+                    poetry install --only main,typecheck
             # https://github.com/typeddjango/django-stubs/issues/458
-            - name: create .env file
-              run: cp example.env .env
-            - uses: pre-commit/action@v3.0.0
+            -   name: create .env file
+                run: cp example.env .env
+            -   uses: pre-commit/action@v3.0.0
 
     unit_test:
         needs: [ lint ]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v4
-              with:
-                  python-version: '3.11'
-            - name: Install dependencies
-              run: |
-                  pip install poetry
-                  poetry config virtualenvs.create false
-                  poetry install --only main
-            - name: create .env file
-              run: cp example.env .env
-            - name: Run tests
-              env:
-                  SECRET_KEY: secret
-                  DB_ENGINE: django.db.backends.sqlite3
-              run: |
-                  cd src
-                  python manage.py makemigrations --check
-                  python manage.py migrate
-                  python manage.py test tests/
+            -   uses: actions/checkout@v4
+            -   uses: actions/setup-python@v4
+                with:
+                    python-version: '3.11'
+            -   name: Install dependencies
+                run: |
+                    pip install poetry
+                    poetry config virtualenvs.create false
+                    poetry install --only main
+            -   name: create .env file
+                run: cp example.env .env
+            -   name: Run tests
+                env:
+                    SECRET_KEY: secret
+                    DB_ENGINE: django.db.backends.sqlite3
+                run: |
+                    cd src
+                    python manage.py makemigrations --check
+                    python manage.py migrate
+                    python manage.py test tests/
 
     docker:
         needs: [ lint, unit_test ]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - name: Build docker image
-              run: |
-                  docker pull $IMAGE_NAME
-                  docker build --pull --cache-from $IMAGE_NAME -t $IMAGE_NAME:latest .
+            -   uses: actions/checkout@v4
+            -   name: Build docker image
+                run: |
+                    docker pull $IMAGE_NAME
+                    docker build --pull --cache-from $IMAGE_NAME -t $IMAGE_NAME:latest .
 
-            - name: Log in into Docker Hub
-              if: ${{ github.event_name == 'push' }}
-              run: |
-                  echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+            -   name: Log in into Docker Hub
+                if: ${{ github.event_name == 'push' }}
+                run: |
+                    echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-            # Context:
-            # For some reason, commits from semantic-release bot does not trigger any actions.
-            # Build/push steps were copied into release workflow until we figure out a better way.
-            # - name: Add a release tag to image
-            #   if: contains(github.ref, 'refs/tags/')
-            #   run: |
-            #     docker tag $IMAGE_NAME $IMAGE_NAME:${GITHUB_REF#refs/tags/}
-
-            - name: Push image to registry
-              if: ${{ github.event_name == 'push' }}
-              run: |
-                  docker push $IMAGE_NAME
+            -   name: Push image to registry
+                if: ${{ github.event_name == 'push' }}
+                run: |
+                    docker push $IMAGE_NAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,54 +1,38 @@
 name: Release
 on:
-  push:
-    branches:
-      - main
+    push:
+        tags:
+            - "v*"
 
+env:
+    IMAGE_NAME: unitystation/central-command
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - name: plugins
-        run: npm install @semantic-release/changelog -D @semantic-release/git -D
-      - name: generate release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v4
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [release]
-    env:
-      IMAGE_NAME: unitystation/central-command
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+            -   name: Extract Tag Name
+                id: extract_tag
+                run: echo "::set-output name=tag::${GITHUB_REF#refs/tags/}"
 
-      - name: Get Latest Tag
-        id: lasttag
-        uses: WyriHaximus/github-action-get-previous-tag@1.0.0
+            -   name: Build docker image with tag
+                run: |
+                    docker pull $IMAGE_NAME:latest
+                    docker build --pull --cache-from $IMAGE_NAME:latest -t $IMAGE_NAME:${{ steps.extract_tag.outputs.tag }} .
 
-      # Steps below are copied from main workflow
-      - name: Build image
-        run: |
-          docker pull $IMAGE_NAME
-          docker build --pull --cache-from $IMAGE_NAME -t $IMAGE_NAME:latest .
+            -   name: Tag image as stable
+                run: |
+                    docker tag $IMAGE_NAME:${{ steps.extract_tag.outputs.tag }} $IMAGE_NAME:stable
 
-      - name: Log in into Docker Hub
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+            -   name: Log in into Docker Hub
+                run: |
+                    echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Add a release tag to image
-        run: |
-          docker tag $IMAGE_NAME $IMAGE_NAME:${{ steps.lasttag.outputs.tag }}
+            -   name: Push tagged image to registry
+                run: |
+                    docker push $IMAGE_NAME:${{ steps.extract_tag.outputs.tag }}
 
-      - name: Push image to registry
-        run: |
-          docker push $IMAGE_NAME
+            -   name: Push stable image to registry
+                run: |
+                    docker push $IMAGE_NAME:stable


### PR DESCRIPTION
Now every time a PR is merged on develop, it will create a new ``latest`` image and push it to dockerhub.

And every time a release is created, it will create a new versioned imagen along a ``stable`` image and push it to dockerhub.

This way we have an staging version of the application and a production version.