### PR TITLE
feat: add ability to search fields and filter fields in Account admin view

### DIFF
--- a/src/accounts/admin.py
+++ b/src/accounts/admin.py
@@ -28,12 +28,13 @@ class PasswordResetRequestInline(admin.TabularInline):
 @admin.register(Account)
 class AccountAdminView(admin.ModelAdmin):
     list_display = (
-        "email",
-        "is_active",
         "unique_identifier",
+        "email",
         "username",
         "is_confirmed",
         "is_verified",
+        "is_active",
+        "is_staff",
         "legacy_id",
     )
     fieldsets = (
@@ -57,6 +58,7 @@ class AccountAdminView(admin.ModelAdmin):
                     "is_active",
                     "is_confirmed",
                     "is_verified",
+                    "is_staff",
                 ),
             },
         ),

--- a/src/accounts/admin.py
+++ b/src/accounts/admin.py
@@ -65,3 +65,9 @@ class AccountAdminView(admin.ModelAdmin):
         ("Legacy", {"classes": ("wide",), "fields": ("legacy_id",)}),
     )
     inlines = [AccountConfirmationInline, PasswordResetRequestInline]
+    list_filter = ("is_staff", "is_verified", "is_confirmed", "is_active")
+    search_fields = (
+        "email__icontains",
+        "username__icontains",
+        "unique_identifier__icontains",
+    )


### PR DESCRIPTION
fix #90

![image](https://github.com/unitystation/central-command/assets/43683714/d6060b56-175a-4230-93a3-527f953f950c)
you can search for partial emails, unique identifiers, usernames.

![image](https://github.com/unitystation/central-command/assets/43683714/a224d2a2-44e6-4b3b-ae8b-545d15b5a130)
You can filter by any of the boolean fields in the account model.

